### PR TITLE
User0824/feat/dashboard

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -30,7 +30,6 @@ async function loadConfig() {
           secure: false,
         },
       },
-      historyApiFallback: true,
     },
   });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
fix: added Vercel json to be able to serve all routes that don't start with api. This allows react router to hand routing client-side. The regex matches all paths except those starting with api so that the api route will still work normally.